### PR TITLE
Fix disappearing mnemonic entry field

### DIFF
--- a/src/components/ConfirmTxEnterSecretsFooter.tsx
+++ b/src/components/ConfirmTxEnterSecretsFooter.tsx
@@ -103,6 +103,9 @@ class ConfirmTxEnterSecretsFooter extends React.Component<
     removeInput1: false
   };
 
+  // We rely on ref based access to the input elements here because
+  // iOS safari auto-fill doesn't work too well with regular onChange
+  // and state updates.
   passphraseRef: HTMLInputElement;
   mnemonicRef: HTMLInputElement;
 

--- a/src/components/ConfirmTxEnterSecretsFooter.tsx
+++ b/src/components/ConfirmTxEnterSecretsFooter.tsx
@@ -229,9 +229,11 @@ class ConfirmTxEnterSecretsFooter extends React.Component<
       mnemonic,
       mnemonicInvalid,
       passphrase,
-      passphraseInvalid
+      passphraseInvalid,
+      removeInput1,
     } = this.state;
     const isPassphraseSet = !!secondPublicKey;
+    const showMnemonicInput = !isPassphraseSet || !removeInput1;
 
     return (
       <Grid
@@ -264,9 +266,10 @@ class ConfirmTxEnterSecretsFooter extends React.Component<
             )}
           </Typography>
         </Grid>
-        {!this.state.removeInput1 && (
-          <Grid item={true} xs={12}>
+        <Grid item={true} xs={12}>
+          {showMnemonicInput ? (
             <TextField
+              key="mnemonic"
               type="password"
               label={
                 <FormattedMessage
@@ -284,31 +287,28 @@ class ConfirmTxEnterSecretsFooter extends React.Component<
               fullWidth={true}
               inputRef={ref => (this.mnemonicRef = ref)}
             />
-          </Grid>
-        )}
-        {this.state.removeInput1 &&
-          isPassphraseSet && (
-            <Grid item={true} xs={12}>
-              <TextField
-                type="password"
-                label={
-                  <FormattedMessage
-                    id="confirm-tx-enter-secrets-footer.passphrase-input-label"
-                    description="Label for 2nd passphrase text field."
-                    defaultMessage="Second passphrase"
-                  />
-                }
-                autoFocus={true}
-                value={passphrase}
-                onChange={this.handlePassphraseChange}
-                onBlur={this.handlePassphraseBlur}
-                error={passphraseInvalid}
-                helperText={passphraseInvalid ? this.passphraseError() : ''}
-                fullWidth={true}
-                inputRef={ref => (this.passphraseRef = ref)}
-              />
-            </Grid>
+          ) : (
+            <TextField
+              key="passphrase"
+              type="password"
+              label={
+                <FormattedMessage
+                  id="confirm-tx-enter-secrets-footer.passphrase-input-label"
+                  description="Label for 2nd passphrase text field."
+                  defaultMessage="Second passphrase"
+                />
+              }
+              autoFocus={true}
+              value={passphrase}
+              onChange={this.handlePassphraseChange}
+              onBlur={this.handlePassphraseBlur}
+              error={passphraseInvalid}
+              helperText={passphraseInvalid ? this.passphraseError() : ''}
+              fullWidth={true}
+              inputRef={ref => (this.passphraseRef = ref)}
+            />
           )}
+        </Grid>
         <Grid item={true} xs={12}>
           <Button type="submit" fullWidth={true}>
             <FormattedMessage


### PR DESCRIPTION
#149 introduced behavior to hide mnemonic field and show passphrase field to get a better experience on mobile. However, the mnemonic field was being hidden regardless if the 2nd passphrase field were shown or not. This is somewhat weird for accounts that don't have the 2nd passphrase set, so this PR fixes this - the mnemonic field stays visible if the 2nd passphrase field isn't going to be shown.

There were a bunch of manual ref management introduced with the changes from #149. This PR does away with them, because I don't see why they would've been necessary - unless, iOS 12 Safari does something weird and the refs were a workaround. If that's the case it should've been documented in the code, but were not.

@TobiaszCudnik do you remember if the manual refs were introduced to work around something or not?