### PR TITLE
Autonaming accounts (#166)

### DIFF
--- a/src/components/content/ConfirmTransactionDialogContent.tsx
+++ b/src/components/content/ConfirmTransactionDialogContent.tsx
@@ -137,7 +137,7 @@ const messages = defineMessages({
   unnamedSender: {
     id: 'confirm-tx-dialog-content.unnamed-sender',
     description: 'Unnamed sender account',
-    defaultMessage: 'Unnamed account'
+    defaultMessage: 'Unnamed account ({id})'
   },
   unnamedRecipient: {
     id: 'confirm-tx-dialog-content.unnamed-recipient',
@@ -222,6 +222,7 @@ interface Props extends BaseProps, ICloseInterruptFormProps {
   data: TxData;
   fee: RawAmount;
   senderName: string | null;
+  senderLocalId: number;
   senderAddress: string;
 }
 
@@ -254,7 +255,10 @@ class ConfirmTransactionDialogContent extends React.Component<DecoratedProps> {
     const recipientAddress = data.kind === 'send' ? data.recipientAddress : '';
     let senderName = this.props.senderName;
     if (!senderName) {
-      senderName = intl.formatMessage(messages.unnamedSender);
+      senderName = intl.formatMessage(
+        messages.unnamedSender,
+        { id: this.props.senderLocalId}
+      );
     }
     let recipientName = data.kind === 'send' ? data.recipientName : null;
     if (!recipientName) {

--- a/src/containers/wallet/AccountOverview.tsx
+++ b/src/containers/wallet/AccountOverview.tsx
@@ -105,7 +105,7 @@ const messages = defineMessages({
   unnamedAccountLabel: {
     id: 'wallet-account-overview.unnamed-account-label',
     description: 'Label for accounts that user hasn\'t named yet',
-    defaultMessage: 'Unnamed account'
+    defaultMessage: 'Unnamed account ({id})'
   },
   noPubkeyAccountTip: {
     id: 'wallet-account-overview.no-pubkey-account-tip',
@@ -249,14 +249,14 @@ class AccountOverview extends React.Component<DecoratedProps, State> {
     // mark the current account as viewed
     this.account.viewed = true;
     const { intl, classes } = this.injected;
-    const unnamedAccountLabel = intl.formatMessage(
-      messages.unnamedAccountLabel
-    );
 
     const readOnly = this.account && this.account.type === AccountType.READONLY;
     const headerProps = {
       address: this.account.id,
-      alias: this.account.name || unnamedAccountLabel,
+      alias: this.account.name || intl.formatMessage(
+        messages.unnamedAccountLabel,
+        { id: this.account.localId }
+      ),
       balance: this.account.balance,
       balanceFiat: this.account.balanceFiat,
       fiatCurrency: this.account.fiatCurrency

--- a/src/containers/wallet/AccountsList.tsx
+++ b/src/containers/wallet/AccountsList.tsx
@@ -72,7 +72,7 @@ const messages = defineMessages({
   unnamedAccountLabel: {
     id: 'accounts-list.unnamed-account-label',
     description: 'Label for accounts that user hasn\'t named yet',
-    defaultMessage: 'Unnamed account'
+    defaultMessage: 'Unnamed account ({id})'
   },
   addAccountTooltip: {
     id: 'accounts-list.add-account-fab-tooltip',
@@ -100,10 +100,6 @@ class AccountOverview extends React.Component<DecoratedProps, State> {
 
   render() {
     const { walletStore, classes, intl } = this.injected;
-
-    const unnamedAccountLabel = intl.formatMessage(
-      messages.unnamedAccountLabel
-    );
     const { selectedAccount } = walletStore;
 
     return (
@@ -138,7 +134,10 @@ class AccountOverview extends React.Component<DecoratedProps, State> {
                   classes={{
                     primary: classes.accountName
                   }}
-                  primary={account.name || unnamedAccountLabel}
+                  primary={account.name || intl.formatMessage(
+                    messages.unnamedAccountLabel,
+                    { id: account.localId }
+                  )}
                   secondary={account.id}
                 />
               </ListItem>

--- a/src/containers/wallet/ConfirmTransactionDialog.tsx
+++ b/src/containers/wallet/ConfirmTransactionDialog.tsx
@@ -420,6 +420,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
         data={transaction!}
         fee={this.fee}
         senderName={account.name}
+        senderLocalId={account.localId}
         senderAddress={account.id}
       >
         {account.type === AccountType.LEDGER ? (
@@ -457,6 +458,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
         data={transaction!}
         fee={this.fee}
         senderName={account.name}
+        senderLocalId={account.localId}
         senderAddress={account.id}
       >
         <ConfirmTxStatusFooter type="broadcasting" />
@@ -476,6 +478,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
         data={transaction!}
         fee={this.fee}
         senderName={account.name}
+        senderLocalId={account.localId}
         senderAddress={account.id}
       >
         <ConfirmTxStatusFooter
@@ -498,6 +501,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
         data={transaction!}
         fee={this.fee}
         senderName={account.name}
+        senderLocalId={account.localId}
         senderAddress={account.id}
       >
         <ConfirmTxStatusFooter

--- a/src/containers/wallet/DrawerContent.tsx
+++ b/src/containers/wallet/DrawerContent.tsx
@@ -94,7 +94,7 @@ const messages = defineMessages({
   unnamedAccountLabel: {
     id: 'drawer-content.unnamed-account-label',
     description: 'Label for accounts that user hasn\'t named yet',
-    defaultMessage: 'Unnamed account'
+    defaultMessage: 'Unnamed account ({id})'
   },
   accountsListAriaLabel: {
     id: 'drawer-content.accounts-list-aria-label',
@@ -157,9 +157,6 @@ class DrawerContent extends React.Component<DecoratedProps> {
       walletStore
     } = this.injected;
 
-    const unnamedAccountLabel = intl.formatMessage(
-      messages.unnamedAccountLabel
-    );
     const { selectedAccount } = walletStore;
 
     let selection: 'addressBook' | 'account' = 'account';
@@ -228,7 +225,10 @@ class DrawerContent extends React.Component<DecoratedProps> {
                   classes={{
                     primary: classes.accountName
                   }}
-                  primary={account.name || unnamedAccountLabel}
+                  primary={account.name || intl.formatMessage(
+                    messages.unnamedAccountLabel,
+                    { id: account.localId }
+                  )}
                   secondary={account.id}
                 />
               </ListItem>

--- a/src/containers/wallet/Settings.tsx
+++ b/src/containers/wallet/Settings.tsx
@@ -87,7 +87,7 @@ const messages = defineMessages({
   unnamedAccountLabel: {
     id: 'account-settings.unnamed-account-label',
     description: 'Label for accounts that user hasn\'t named yet',
-    defaultMessage: 'Unnamed account'
+    defaultMessage: 'Unnamed account ({id})'
   },
   accountName: {
     id: 'account-settings.account-name',
@@ -268,7 +268,10 @@ class AccountSettings extends React.Component<DecoratedProps, State> {
                   primary={intl.formatMessage(messages.accountName)}
                   secondary={
                     account.name ||
-                    intl.formatMessage(messages.unnamedAccountLabel)
+                    intl.formatMessage(
+                      messages.unnamedAccountLabel,
+                      { id: this.account.localId }
+                    )
                   }
                 />
               </ListItem>

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -22,6 +22,7 @@ export enum AccountType {
 
 type ImportableFields =
   | 'id'
+  | 'localId'
   | 'publicKey'
   | 'broadcastedPublicKey'
   | 'type'
@@ -44,6 +45,7 @@ export default class AccountStore {
   @observable loaded: boolean = false;
 
   @observable id: string;
+  @observable localId: number;
   @observable publicKey: string | null = null;
   @observable broadcastedPublicKey: string | null = null;
 

--- a/src/stores/fixtures.ts
+++ b/src/stores/fixtures.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 export const storedAccounts = [
   {
     id: '2655711995542512317R',
+    localId: 1,
     publicKey:
       '023bab3e17365565d7a796291f8d3bb6878a3083ea520fbd163db713d51b44f9',
     type: 1,
@@ -17,6 +18,7 @@ export const storedAccounts = [
   },
   {
     id: '5932278668828702947R',
+    localId: 2,
     publicKey:
       '491e09b538aa8d44a613bc5d23e2b6a4f93126b89c8fb8766016708af519fded',
     type: 1,
@@ -28,6 +30,7 @@ export const storedAccounts = [
   },
   {
     id: '11543739950532038814R',
+    localId: 3,
     publicKey:
       '63a12d153b3c72ed71392da9aac6b897c4b908f9ff17201794d69b4622d30aee',
     type: 1,
@@ -39,6 +42,7 @@ export const storedAccounts = [
   },
   {
     id: '10317456780953445784R',
+    localId: 4,
     publicKey:
       'e9ae239743b47125305a3f339937661368a7f8d810ae53d79e5c4de001356563',
     type: 1,


### PR DESCRIPTION
Adds `localId` property to accounts. This is used in the `"Unnamed account ({id})"` labels.

Closes #166 