### PR TITLE
webusb transport for Ledger Nano

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rise-wallet-desktop",
   "description": "Rise Wallet",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "rise.vision",
   "engines": {
     "yarn": "^1.10.1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rise-wallet-desktop",
   "description": "Rise Wallet",
-  "version": "1.2.0",
+  "version": "1.2.0-beta1",
   "author": "rise.vision",
   "engines": {
     "yarn": "^1.10.1"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rise-wallet-desktop",
   "description": "Rise Wallet",
-  "version": "1.2.0-beta1",
+  "version": "1.2.0-beta2",
   "author": "rise.vision",
   "engines": {
     "yarn": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-wallet",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "engines": {
     "yarn": "^1.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "license": "GPL-3.0-only",
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@ledgerhq/hw-transport-u2f": "^4.48.0",
+    "@ledgerhq/hw-transport-webusb": "^4.48.0",
     "@material-ui/core": "^3.7.0",
     "@material-ui/icons": "^3.0.1",
+    "@types/ledgerhq__hw-transport": "^4.21.1",
+    "@types/w3c-web-usb": "^1.0.3",
     "async-mutex": "^0.1.3",
     "babel-cli": "^6.26.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-wallet",
-  "version": "1.2.0-beta1",
+  "version": "1.2.0-beta2",
   "engines": {
     "yarn": "^1.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-wallet",
-  "version": "1.2.0",
+  "version": "1.2.0-beta1",
   "engines": {
     "yarn": "^1.10.1"
   },

--- a/src/components/ConfirmTxStatusFooter.tsx
+++ b/src/components/ConfirmTxStatusFooter.tsx
@@ -73,11 +73,6 @@ const messages = defineMessages({
     id: 'confirm-tx-status-footer.success-icon-aria',
     description: 'Success status icon label for accessibility',
     defaultMessage: 'Success indicator icon'
-  },
-  ledgerDoubleConfirmLink: {
-    id: 'confirm-tx-status-footer.ledger-dobule-confirm-link',
-    description: 'text content for the ledger issue link',
-    defaultMessage: 'known issue'
   }
 });
 
@@ -189,40 +184,18 @@ class ConfirmTxStatusFooter extends React.Component<DecoratedProps> {
                 }
               />
             ) : type === 'ledger-confirming' ? (
-              <React.Fragment>
-                <FormattedMessage
-                  id="confirm-tx-status-footer.ledger-confirming-msg"
-                  description="Message for when the user needs to confirm the transaction on Ledger."
-                  defaultMessage={
-                    'Please confirm the transaction on your Ledger. Waiting for confirmation... ' +
-                    '({seconds} {seconds, plural,' +
-                    '  one {second}' +
-                    '  other {seconds}' +
-                    '} remaining)'
-                  }
-                  values={{ seconds: timeout || 0 }}
-                />
-                <br />
-                <br />
-                <FormattedMessage
-                  id="confirm-tx-status-footer.ledger-confirming-msg-twice"
-                  description="Double confirmation issue notification."
-                  defaultMessage={
-                    'You may have to confirm twice. Its a {link}.'}
-                  values={{
-                    seconds: timeout || 0,
-
-                    link: (
-                      <a
-                        href="https://support.ledger.com/hc/en-us/articles/360018810413-U2F-timeout-in-Chrome-browser"
-                        target="_blank"
-                      >
-                        {intl.formatMessage(messages.ledgerDoubleConfirmLink)}
-                      </a>
-                    )
-                  }}
-                />
-              </React.Fragment>
+              <FormattedMessage
+                id="confirm-tx-status-footer.ledger-confirming-msg"
+                description="Message for when the user needs to confirm the transaction on Ledger."
+                defaultMessage={
+                  'Please confirm the transaction on your Ledger. Waiting for confirmation... ' +
+                  '({seconds} {seconds, plural,' +
+                  '  one {second}' +
+                  '  other {seconds}' +
+                  '} remaining)'
+                }
+                values={{ seconds: timeout || 0 }}
+              />
             ) : null}
           </Typography>
         </Grid>

--- a/src/components/ConfirmTxStatusFooter.tsx
+++ b/src/components/ConfirmTxStatusFooter.tsx
@@ -176,10 +176,10 @@ class ConfirmTxStatusFooter extends React.Component<DecoratedProps> {
               />
             ) : type === 'ledger-not-connected' ? (
               <FormattedMessage
-                id="confirm-tx-status-footer.ledger-not-connected-msg"
+                id="confirm-tx-status-footer.ledger-not-connected-msg-v2"
                 description="Message for when the Ledger device isn't connected."
                 defaultMessage={
-                  'Please connect your Ledger and open the RISE app on it. ' +
+                  'Connect your Ledger, open the RISE app and click Discover Device below.' +
                   'Waiting for Ledger...'
                 }
               />

--- a/src/components/LedgerConnectIllustration.tsx
+++ b/src/components/LedgerConnectIllustration.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@material-ui/core';
 import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
 import * as React from 'react';
 
@@ -34,7 +35,9 @@ const styles = createStyles({
   }
 });
 
-interface Props extends WithStyles<typeof styles> {}
+interface Props extends WithStyles<typeof styles> {
+  onClick(): void;
+}
 
 const stylesDecorator = withStyles(styles, {
   name: 'LedgerConnectIllustration'
@@ -42,77 +45,89 @@ const stylesDecorator = withStyles(styles, {
 
 class LedgerConnectIllustration extends React.Component<Props> {
   render() {
-    const { classes } = this.props;
+    const { classes, onClick } = this.props;
 
     // Source SVG optimised with https://jakearchibald.github.io/svgomg/
     // and relevant animation groups injected by hand
 
     // tslint:disable:max-line-length
     return (
-      <svg
-        className={classes.root}
-        height="90px"
-        viewBox="160 55 240 90"
-        aria-hidden={true}
-      >
-        <g fill="none" fillRule="evenodd">
-          <g className={classes.usbCable}>
-            <g transform="translate(-96 91)" fill="#2F2F2F" stroke="#434242">
-              <path d="M.5 3.5h199v11H.5z" />
-              <rect x="187.5" y=".5" width="29" height="17" rx="4" />
+      <React.Fragment>
+        <svg
+          className={classes.root}
+          height="90px"
+          viewBox="160 55 240 90"
+          aria-hidden={true}
+        >
+          <g fill="none" fillRule="evenodd">
+            <g className={classes.usbCable}>
+              <g transform="translate(-96 91)" fill="#2F2F2F" stroke="#434242">
+                <path d="M.5 3.5h199v11H.5z" />
+                <rect x="187.5" y=".5" width="29" height="17" rx="4" />
+              </g>
+              <g transform="translate(171 88)" fill="#D8D8D8" stroke="#979797">
+                <rect x=".5" y=".5" width="24" height="23" rx="2" />
+                <path d="M.5 3.5h24v17H.5z" />
+              </g>
+              <path
+                d="M176 82.5h-60c-6.351 0-11.5 5.149-11.5 11.5v12c0 6.351 5.149 11.5 11.5 11.5h60a1.5 1.5 0 0 0 1.5-1.5V84a1.5 1.5 0 0 0-1.5-1.5z"
+                stroke="#434242"
+                fill="#2F2F2F"
+              />
             </g>
-            <g transform="translate(171 88)" fill="#D8D8D8" stroke="#979797">
-              <rect x=".5" y=".5" width="24" height="23" rx="2" />
-              <path d="M.5 3.5h24v17H.5z" />
+            <rect
+              fill="#4C575B"
+              x="212"
+              y="83"
+              width="130"
+              height="34"
+              rx="1"
+            />
+            <g className={classes.homeScreen} fill="#A7CAED">
+              <path d="M269.613 109.918h-.933V112h-1.172v-5.688h2.113c.672 0 1.19.15 1.555.45.364.3.547.722.547 1.27 0 .387-.084.71-.252.97-.168.26-.423.465-.764.62l1.23 2.323V112h-1.257l-1.067-2.082zm-.933-.95h.945c.294 0 .522-.074.684-.224.161-.15.242-.356.242-.619 0-.268-.076-.48-.229-.633-.152-.153-.386-.23-.7-.23h-.942v1.707zm6.094 3.032h-1.172v-5.688h1.172V112zm4.95-1.492c0-.222-.079-.391-.235-.51-.157-.118-.438-.243-.844-.375a5.981 5.981 0 0 1-.965-.389c-.646-.349-.969-.819-.969-1.41 0-.307.087-.581.26-.822.173-.24.422-.43.746-.565a2.808 2.808 0 0 1 1.092-.203c.406 0 .768.074 1.086.221.318.147.564.355.74.623.176.268.264.573.264.914h-1.172c0-.26-.082-.463-.246-.607-.164-.145-.395-.217-.691-.217-.287 0-.51.06-.668.182a.573.573 0 0 0-.239.478c0 .185.093.34.28.465.186.125.46.242.822.352.666.2 1.152.449 1.457.746.305.297.457.666.457 1.109 0 .492-.186.878-.559 1.158-.372.28-.873.42-1.504.42-.437 0-.836-.08-1.195-.24-.36-.16-.633-.38-.822-.658a1.686 1.686 0 0 1-.283-.97h1.175c0 .629.375.942 1.125.942.279 0 .496-.056.653-.17a.553.553 0 0 0 .234-.474zm6.304-.973h-2.25v1.524h2.64V112h-3.812v-5.687h3.805v.949h-2.633v1.355h2.25v.918zM274 87h6a5 5 0 0 1 5 5v6a5 5 0 0 1-5 5h-6a5 5 0 0 1-5-5v-6a5 5 0 0 1 5-5zm0 3v2h2v-2h-2zm4 8v2h2v-2h-2zm0-7v1h1v-1h-1zm1-1v1h1v-1h-1zm-2 2v1h1v-1h-1zm2 0v1h1v-1h-1zm-1 1v1h1v-1h-1zm1 1v1h1v-1h-1zm-1 1v1h1v-1h-1zm-1-1v1h1v-1h-1zm-1-1v1h1v-1h-1zm-1 1v1h1v-1h-1zm1 1v1h1v-1h-1zm1 1v1h1v-1h-1zm-1 1v1h1v-1h-1zm-1-1v1h1v-1h-1zm-1-1v1h1v-1h-1zm0 2v1h1v-1h-1zm1 1v1h1v-1h-1zm-1 1v1h1v-1h-1z" />
+            </g>
+            <g className={classes.rightButton}>
+              <rect
+                stroke="#434242"
+                strokeWidth="2"
+                fill="#2F2F2F"
+                x="331"
+                y="62"
+                width="18"
+                height="8"
+                rx="2"
+              />
+            </g>
+            <g className={classes.leftButton}>
+              <rect
+                stroke="#434242"
+                strokeWidth="2"
+                fill="#2F2F2F"
+                x="205"
+                y="62"
+                width="18"
+                height="8"
+                rx="2"
+              />
             </g>
             <path
-              d="M176 82.5h-60c-6.351 0-11.5 5.149-11.5 11.5v12c0 6.351 5.149 11.5 11.5 11.5h60a1.5 1.5 0 0 0 1.5-1.5V84a1.5 1.5 0 0 0-1.5-1.5z"
-              stroke="#434242"
-              fill="#2F2F2F"
-            />
-          </g>
-          <rect fill="#4C575B" x="212" y="83" width="130" height="34" rx="1" />
-          <g className={classes.homeScreen} fill="#A7CAED">
-            <path d="M269.613 109.918h-.933V112h-1.172v-5.688h2.113c.672 0 1.19.15 1.555.45.364.3.547.722.547 1.27 0 .387-.084.71-.252.97-.168.26-.423.465-.764.62l1.23 2.323V112h-1.257l-1.067-2.082zm-.933-.95h.945c.294 0 .522-.074.684-.224.161-.15.242-.356.242-.619 0-.268-.076-.48-.229-.633-.152-.153-.386-.23-.7-.23h-.942v1.707zm6.094 3.032h-1.172v-5.688h1.172V112zm4.95-1.492c0-.222-.079-.391-.235-.51-.157-.118-.438-.243-.844-.375a5.981 5.981 0 0 1-.965-.389c-.646-.349-.969-.819-.969-1.41 0-.307.087-.581.26-.822.173-.24.422-.43.746-.565a2.808 2.808 0 0 1 1.092-.203c.406 0 .768.074 1.086.221.318.147.564.355.74.623.176.268.264.573.264.914h-1.172c0-.26-.082-.463-.246-.607-.164-.145-.395-.217-.691-.217-.287 0-.51.06-.668.182a.573.573 0 0 0-.239.478c0 .185.093.34.28.465.186.125.46.242.822.352.666.2 1.152.449 1.457.746.305.297.457.666.457 1.109 0 .492-.186.878-.559 1.158-.372.28-.873.42-1.504.42-.437 0-.836-.08-1.195-.24-.36-.16-.633-.38-.822-.658a1.686 1.686 0 0 1-.283-.97h1.175c0 .629.375.942 1.125.942.279 0 .496-.056.653-.17a.553.553 0 0 0 .234-.474zm6.304-.973h-2.25v1.524h2.64V112h-3.812v-5.687h3.805v.949h-2.633v1.355h2.25v.918zM274 87h6a5 5 0 0 1 5 5v6a5 5 0 0 1-5 5h-6a5 5 0 0 1-5-5v-6a5 5 0 0 1 5-5zm0 3v2h2v-2h-2zm4 8v2h2v-2h-2zm0-7v1h1v-1h-1zm1-1v1h1v-1h-1zm-2 2v1h1v-1h-1zm2 0v1h1v-1h-1zm-1 1v1h1v-1h-1zm1 1v1h1v-1h-1zm-1 1v1h1v-1h-1zm-1-1v1h1v-1h-1zm-1-1v1h1v-1h-1zm-1 1v1h1v-1h-1zm1 1v1h1v-1h-1zm1 1v1h1v-1h-1zm-1 1v1h1v-1h-1zm-1-1v1h1v-1h-1zm-1-1v1h1v-1h-1zm0 2v1h1v-1h-1zm1 1v1h1v-1h-1zm-1 1v1h1v-1h-1z" />
-          </g>
-          <g className={classes.rightButton}>
-            <rect
+              d="M184 67a3 3 0 0 0-3 3v60a3 3 0 0 0 3 3h246a3 3 0 0 0 3-3V70a3 3 0 0 0-3-3H184zm30 16h126a2 2 0 0 1 2 2v30a2 2 0 0 1-2 2H214a2 2 0 0 1-2-2V85a2 2 0 0 1 2-2zm186 35c-9.941 0-18-8.059-18-18s8.059-18 18-18 18 8.059 18 18-8.059 18-18 18z"
               stroke="#434242"
               strokeWidth="2"
               fill="#2F2F2F"
-              x="331"
-              y="62"
-              width="18"
-              height="8"
-              rx="2"
             />
-          </g>
-          <g className={classes.leftButton}>
-            <rect
-              stroke="#434242"
+            <path
+              d="M400 132h222a3 3 0 0 0 3-3V71a3 3 0 0 0-3-3H400c-17.673 0-32 14.327-32 32 0 17.673 14.327 32 32 32zm0-9c-12.703 0-23-10.297-23-23s10.297-23 23-23 23 10.297 23 23-10.297 23-23 23z"
+              stroke="#AEAEAE"
               strokeWidth="2"
-              fill="#2F2F2F"
-              x="205"
-              y="62"
-              width="18"
-              height="8"
-              rx="2"
+              fill="#C7C7C7"
             />
           </g>
-          <path
-            d="M184 67a3 3 0 0 0-3 3v60a3 3 0 0 0 3 3h246a3 3 0 0 0 3-3V70a3 3 0 0 0-3-3H184zm30 16h126a2 2 0 0 1 2 2v30a2 2 0 0 1-2 2H214a2 2 0 0 1-2-2V85a2 2 0 0 1 2-2zm186 35c-9.941 0-18-8.059-18-18s8.059-18 18-18 18 8.059 18 18-8.059 18-18 18z"
-            stroke="#434242"
-            strokeWidth="2"
-            fill="#2F2F2F"
-          />
-          <path
-            d="M400 132h222a3 3 0 0 0 3-3V71a3 3 0 0 0-3-3H400c-17.673 0-32 14.327-32 32 0 17.673 14.327 32 32 32zm0-9c-12.703 0-23-10.297-23-23s10.297-23 23-23 23 10.297 23 23-10.297 23-23 23z"
-            stroke="#AEAEAE"
-            strokeWidth="2"
-            fill="#C7C7C7"
-          />
-        </g>
-      </svg>
+        </svg>
+        <Button onClick={onClick} color="secondary" fullWidth={true}>
+          Discover Device
+        </Button>
+      </React.Fragment>
     );
     // tslint:enable:max-line-length
   }

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -11,12 +11,12 @@ type BaseProps = Overwrite<
 >;
 
 interface Props extends BaseProps {
-  onClick?(ev: React.MouseEvent<HTMLAnchorElement>): void;
   children: React.ReactElement<
     React.AnchorHTMLAttributes<HTMLAnchorElement> & {
       component: React.ReactType;
     }
   >;
+  onClick?(ev: React.MouseEvent<HTMLAnchorElement>): void;
 }
 
 interface PropsInjected extends Props {
@@ -71,7 +71,7 @@ class Link extends React.Component<Props> {
       ev.preventDefault();
       store.navigateTo(routeLink);
     }
-  };
+  }
 
   render() {
     const {
@@ -95,7 +95,7 @@ class Link extends React.Component<Props> {
         href: store.linkUrl(routeLink),
         // compose onClick if a handler passed
         onClick: onClick
-          ? e => {
+          ? (e: React.MouseEvent<HTMLAnchorElement>) => {
               onClick(e);
               this.handleClick(e);
             }

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -11,6 +11,7 @@ type BaseProps = Overwrite<
 >;
 
 interface Props extends BaseProps {
+  onClick?(ev: React.MouseEvent<HTMLAnchorElement>): void;
   children: React.ReactElement<
     React.AnchorHTMLAttributes<HTMLAnchorElement> & {
       component: React.ReactType;
@@ -70,7 +71,7 @@ class Link extends React.Component<Props> {
       ev.preventDefault();
       store.navigateTo(routeLink);
     }
-  }
+  };
 
   render() {
     const {
@@ -79,6 +80,7 @@ class Link extends React.Component<Props> {
       queryParams,
       onBeforeNavigate,
       onAfterNavigate,
+      onClick,
       children,
       store,
       ...passthroughProps
@@ -91,7 +93,13 @@ class Link extends React.Component<Props> {
       overrideProps = {
         component: 'a',
         href: store.linkUrl(routeLink),
-        onClick: this.handleClick
+        // compose onClick if a handler passed
+        onClick: onClick
+          ? e => {
+              onClick(e);
+              this.handleClick(e);
+            }
+          : this.handleClick
       };
     }
 

--- a/src/components/content/SendCoinsDialogContent.tsx
+++ b/src/components/content/SendCoinsDialogContent.tsx
@@ -227,7 +227,7 @@ class SendCoinsDialogContent extends React.Component<DecoratedProps, State> {
   handleAmountBlur = () => {
     const amountInvalid = !!this.state.amount && !!this.amountError();
     const amount = this.state.parsedAmount
-      ? this.state.parsedAmount.unit.toNumber().toString()
+      ? this.state.parsedAmount.unit.toString()
       : '';
     this.setState({
       amountInvalid,

--- a/src/components/content/VoteDelegateDialogContent.tsx
+++ b/src/components/content/VoteDelegateDialogContent.tsx
@@ -85,6 +85,7 @@ type BaseProps = WithStyles<typeof styles> & DialogContentProps;
 interface Props extends BaseProps, ICloseInterruptFormProps {
   query: string;
   onQueryChange: (query: string) => void;
+  // TODO rename to onSubmit
   onSelect: (delegate: Delegate) => void;
   isLoading: boolean;
   votedDelegate: null | Delegate;

--- a/src/containers/onboarding/AddAccountPage.tsx
+++ b/src/containers/onboarding/AddAccountPage.tsx
@@ -65,16 +65,12 @@ class AddAccountPage extends React.Component<Props> {
   handleBeforeNavigate = () => {
     const { onboardingStore } = this.injected;
     onboardingStore.reset();
-  }
+  };
 
-  componentWillMount() {
-    // establish communication with a ledger
-    this.injected.ledgerStore.open();
-  }
-
-  componentWillUnmount() {
-    this.injected.ledgerStore.close();
-  }
+  preserveLedgerContext = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    this.injected.ledgerStore.open()
+    // this.injected.ledgerStore.eventContext = event;
+  };
 
   render() {
     const { classes, langStore, walletStore } = this.injected;
@@ -191,6 +187,7 @@ class AddAccountPage extends React.Component<Props> {
           <Link
             route={onboardingLedgerAccount}
             onBeforeNavigate={this.handleBeforeNavigate}
+            onClick={this.preserveLedgerContext}
           >
             <ListItem button={true}>
               <ListItemText

--- a/src/containers/onboarding/AddAccountPage.tsx
+++ b/src/containers/onboarding/AddAccountPage.tsx
@@ -65,12 +65,11 @@ class AddAccountPage extends React.Component<Props> {
   handleBeforeNavigate = () => {
     const { onboardingStore } = this.injected;
     onboardingStore.reset();
-  };
+  }
 
-  preserveLedgerContext = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    this.injected.ledgerStore.open()
-    // this.injected.ledgerStore.eventContext = event;
-  };
+  handleAddLedgerClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    this.injected.ledgerStore.open();
+  }
 
   render() {
     const { classes, langStore, walletStore } = this.injected;
@@ -187,7 +186,7 @@ class AddAccountPage extends React.Component<Props> {
           <Link
             route={onboardingLedgerAccount}
             onBeforeNavigate={this.handleBeforeNavigate}
-            onClick={this.preserveLedgerContext}
+            onClick={this.handleAddLedgerClick}
           >
             <ListItem button={true}>
               <ListItemText

--- a/src/containers/onboarding/LedgerAccountPage.tsx
+++ b/src/containers/onboarding/LedgerAccountPage.tsx
@@ -66,9 +66,9 @@ const messages = defineMessages({
   unsupportedBrowser: {
     id: 'onboarding-ledger-account.unsupported-browser',
     description:
-      "Message when trying to use a browser that doesn't support Ledger devices",
+      'Message when trying to use a browser that doesn\'t support Ledger devices',
     defaultMessage:
-      "Your browser doesn't support using a Ledger device. If you wish to access this feature, " +
+      'Your browser doesn\'t support using a Ledger device. If you wish to access this feature, ' +
       'you could try again with Google Chrome. It is a browser known to implement support for this.'
   },
   statusConnecting: {
@@ -109,8 +109,12 @@ const messages = defineMessages({
 @inject('ledgerStore')
 @observer
 class LedgerAccountPage extends React.Component<DecoratedProps> {
-  private countdownId: null | number = null;
+
+  get injected(): PropsInjected {
+    return this.props as PropsInjected;
+  }
   accountsToShow: number = 5;
+  private countdownId: null | number = null;
 
   @observable private selectedAccount: null | LedgerAccount = null;
   @observable private selectionTimeout: null | Date = null;
@@ -120,10 +124,6 @@ class LedgerAccountPage extends React.Component<DecoratedProps> {
     new Array(this.accountsToShow)
   );
   private loadingAccounts = false;
-
-  get injected(): PropsInjected {
-    return this.props as PropsInjected;
-  }
 
   // async componentWillMount() {
   //   const { ledgerStore } = this.injected;
@@ -294,7 +294,7 @@ class LedgerAccountPage extends React.Component<DecoratedProps> {
       window.clearInterval(this.countdownId);
       this.countdownId = null;
     }
-  };
+  }
 
   private async confirmImport(account: LedgerAccount) {
     const { walletStore, routerStore, ledgerStore } = this.injected;
@@ -373,7 +373,7 @@ class LedgerAccountPage extends React.Component<DecoratedProps> {
         this.accounts[index] = data;
       });
 
-      index++
+      index++;
     }
   }
 }

--- a/src/containers/onboarding/LedgerAccountPage.tsx
+++ b/src/containers/onboarding/LedgerAccountPage.tsx
@@ -57,11 +57,12 @@ const stylesDecorator = withStyles(styles, {
 });
 
 const messages = defineMessages({
-  connectInstructions: {
+  connectInstructionsV2: {
     id: 'onboarding-ledger-account.connect-instructions',
     description:
       'Text instructing the user to open the RISE app on their Ledger device',
-    defaultMessage: 'Connect your Ledger & open the RISE app on it.'
+    defaultMessage:
+      'Connect your Ledger, open the RISE app and click Discover Device below.'
   },
   unsupportedBrowser: {
     id: 'onboarding-ledger-account.unsupported-browser',
@@ -109,7 +110,6 @@ const messages = defineMessages({
 @inject('ledgerStore')
 @observer
 class LedgerAccountPage extends React.Component<DecoratedProps> {
-
   get injected(): PropsInjected {
     return this.props as PropsInjected;
   }
@@ -134,6 +134,10 @@ class LedgerAccountPage extends React.Component<DecoratedProps> {
 
   componentWillUnmount() {
     this.injected.ledgerStore.close();
+  }
+
+  onDiscoverLedger = () => {
+    this.injected.ledgerStore.open();
   }
 
   render() {
@@ -164,12 +168,12 @@ class LedgerAccountPage extends React.Component<DecoratedProps> {
           <Grid container={true} className={classes.content} spacing={16}>
             <Grid item={true} xs={12}>
               <Typography
-                children={intl.formatMessage(messages.connectInstructions)}
+                children={intl.formatMessage(messages.connectInstructionsV2)}
               />
             </Grid>
             <Grid item={true} xs={12}>
               <div className={classes.noPadding}>
-                <LedgerConnectIllustration />
+                <LedgerConnectIllustration onClick={this.onDiscoverLedger} />
               </div>
             </Grid>
             <Grid item={true} xs={12}>

--- a/src/containers/wallet/AccountOverview.tsx
+++ b/src/containers/wallet/AccountOverview.tsx
@@ -340,10 +340,7 @@ class AccountOverview extends React.Component<DecoratedProps, State> {
                         )}
                         onExpand={this.handleExpand}
                         getSendLinkProps={this.getSendLinkProps}
-                        key={
-                          transaction.id +
-                          (transaction.confirmations ? 'C' : 'U')
-                        }
+                        key={transaction.id}
                         tx={transaction}
                         explorerUrl={this.account.config.explorer_url}
                         handleContactEdit={this.handleContactEdit}

--- a/src/containers/wallet/AddSecondPassphraseDialog.tsx
+++ b/src/containers/wallet/AddSecondPassphraseDialog.tsx
@@ -9,7 +9,8 @@ import {
   ICloseInterruptControllerState
 } from '../../components/Dialog';
 import { accountSettingsPassphraseRoute } from '../../routes';
-import AccountStore from '../../stores/account';
+import AccountStore, { AccountType } from '../../stores/account';
+import LedgerStore from '../../stores/ledger';
 import RootStore, { RouteLink } from '../../stores/root';
 import WalletStore from '../../stores/wallet';
 import ConfirmTransactionDialog from './ConfirmTransactionDialog';
@@ -24,6 +25,7 @@ interface PropsInjected extends Props {
   store: RootStore;
   routerStore: RouterStore;
   walletStore: WalletStore;
+  ledgerStore: LedgerStore;
 }
 
 interface State extends ICloseInterruptControllerState {
@@ -37,6 +39,7 @@ interface State extends ICloseInterruptControllerState {
 @inject('store')
 @inject('routerStore')
 @inject('walletStore')
+@inject('ledgerStore')
 @observer
 class AddSecondPassphraseDialog extends React.Component<Props, State>
   implements ICloseInterruptController {
@@ -48,6 +51,10 @@ class AddSecondPassphraseDialog extends React.Component<Props, State>
 
   get injected(): PropsInjected {
     return this.props as PropsInjected;
+  }
+
+  get account(): AccountStore {
+    return this.injected.account;
   }
 
   handleClose = (ev: React.SyntheticEvent<{}>) => {
@@ -73,6 +80,11 @@ class AddSecondPassphraseDialog extends React.Component<Props, State>
   }
 
   handleAddPassphrase = (passphrase: string) => {
+    // ledger requires to be open in a click handler
+    if (this.account.type === AccountType.LEDGER) {
+      this.injected.ledgerStore.open();
+    }
+
     this.setState({
       step: 'transaction',
       transaction: {

--- a/src/containers/wallet/ConfirmTransactionDialog.tsx
+++ b/src/containers/wallet/ConfirmTransactionDialog.tsx
@@ -109,7 +109,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
     } else if (navigateBackLink) {
       store.navigateTo(navigateBackLink);
     }
-  };
+  }
 
   handleClose = (ev: React.SyntheticEvent<{}>) => {
     // close interrupt
@@ -138,11 +138,11 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       store.navigateTo(onCloseRoute);
     }
     return false;
-  };
+  }
 
   handleFormChanged = (changed: boolean) => {
     this.setState({ formChanged: changed });
-  };
+  }
 
   handleConfirmTransaction = async (secrets: Secrets) => {
     const { account, walletStore, onCreateTransaction } = this.injected;
@@ -165,19 +165,18 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
     );
 
     this.broadcastTransaction(signedTx);
-  };
+  }
 
   handleRetryTransaction = () => {
     const { signedTx } = this.state;
     if (signedTx !== null) {
       this.broadcastTransaction(signedTx);
     }
-  };
+  }
 
   async broadcastTransaction(signedTx: PostableRiseTransaction) {
     const { walletStore, onSuccess, onError } = this.injected;
 
-    console.log('sending');
     this.setState({ step: 'sending' });
 
     let success = false;
@@ -207,7 +206,6 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
     // TODO this should switch the dialog to the SENT state when using ledger
     //  works well for non-ledger signed txes
     if (success) {
-      console.log('setState sent');
       this.setState({
         step: 'sent',
         signedTx: null
@@ -265,6 +263,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
     const { account } = this.injected;
 
     if (account.type === AccountType.LEDGER) {
+      // TODO change reaction to a state change listener
       this.disposeLedgerMonitor = reaction(
         this.canSignOnLedger,
         this.beginLedgerSigning
@@ -291,7 +290,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
   }
 
   canSignOnLedger = () => {
-    const { transaction, account, ledgerStore } = this.injected;
+    const { transaction, ledgerStore } = this.injected;
     const { step } = this.state;
 
     return (
@@ -300,7 +299,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       ledgerStore.hasSupport &&
       ledgerStore.isOpen
     );
-  };
+  }
 
   beginLedgerSigning = async () => {
     const { account, onCreateTransaction, ledgerStore } = this.injected;
@@ -309,6 +308,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
 
     if (
       !ledgerStore.isOpen ||
+      !this.canSignOnLedger() ||
       // !this.canSignOnLedger() ||
       account.hwSlot === null
     ) {
@@ -349,7 +349,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
     } else {
       this.goBack();
     }
-  };
+  }
 
   render() {
     const { open } = this.injected;
@@ -555,7 +555,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       window.clearInterval(this.countdownId);
       this.countdownId = null;
     }
-  };
+  }
 }
 
 export default ConfirmTransactionDialog;

--- a/src/containers/wallet/ConfirmTransactionDialog.tsx
+++ b/src/containers/wallet/ConfirmTransactionDialog.tsx
@@ -262,9 +262,7 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       return;
     }
     this.open = true;
-    const { account, ledgerStore } = this.injected;
-    // open the ledger
-    ledgerStore.open();
+    const { account } = this.injected;
 
     if (account.type === AccountType.LEDGER) {
       this.disposeLedgerMonitor = reaction(
@@ -293,18 +291,15 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
   }
 
   canSignOnLedger = () => {
-    // TODO
-    // const { transaction, account, ledgerStore } = this.injected;
-    // const { step } = this.state;
-    //
-    // return (
-    //   step === 'confirm' &&
-    //   transaction !== null &&
-    //   ledgerStore.hasSupport &&
-    //   account.hwId !== null &&
-    //   ledgerStore.isOpen &&
-    //   ledgerStore.deviceId === account.hwId
-    // );
+    const { transaction, account, ledgerStore } = this.injected;
+    const { step } = this.state;
+
+    return (
+      step === 'confirm' &&
+      transaction !== null &&
+      ledgerStore.hasSupport &&
+      ledgerStore.isOpen
+    );
   };
 
   beginLedgerSigning = async () => {
@@ -334,7 +329,9 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       return;
     }
 
-    this.confirmationTimeout = new Date(new Date().getTime() + 25000);
+    this.confirmationTimeout = new Date(
+      new Date().getTime() + ledgerStore.confirmationTimeout
+    );
     this.updateConfirmationCountdown();
 
     let signedTx;
@@ -408,7 +405,6 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       backProps.onNavigateBack = onNavigateBack;
     }
 
-    console.log('step', step);
     switch (step) {
       default:
         return {
@@ -446,28 +442,25 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
         senderLocalId={account.localId}
         senderAddress={account.id}
       >
-        {/* TODO */}
-        {/*{account.type === AccountType.LEDGER ? (*/}
-        {/*  !ledgerStore.isOpen || !ledgerStore.hasSupport ? (*/}
-        {/*    <ConfirmTxStatusFooter type="ledger-not-supported" />*/}
-        {/*  ) : ledgerStore.deviceId === null ? (*/}
-        {/*    <ConfirmTxStatusFooter type="ledger-not-connected" />*/}
-        {/*  ) : ledgerStore.deviceId !== account.hwId ? (*/}
-        {/*    <ConfirmTxStatusFooter type="ledger-another-device" />*/}
-        {/*  ) : (*/}
-        {/*    <ConfirmTxStatusFooter*/}
-        {/*      type="ledger-confirming"*/}
-        {/*      timeout={this.countdownSeconds}*/}
-        {/*    />*/}
-        {/*  )*/}
-        {/*) : (*/}
-        {/*  <ConfirmTxEnterSecretsFooter*/}
-        {/*    address={account.id}*/}
-        {/*    publicKey={account.publicKey}*/}
-        {/*    secondPublicKey={passphrasePublicKey || account.secondPublicKey}*/}
-        {/*    onConfirm={this.handleConfirmTransaction}*/}
-        {/*  />*/}
-        {/*)}*/}
+        {account.type === AccountType.LEDGER ? (
+          !ledgerStore.hasSupport ? (
+            <ConfirmTxStatusFooter type="ledger-not-supported" />
+          ) : !ledgerStore.isOpen ? (
+            <ConfirmTxStatusFooter type="ledger-not-connected" />
+          ) : (
+            <ConfirmTxStatusFooter
+              type="ledger-confirming"
+              timeout={this.countdownSeconds}
+            />
+          )
+        ) : (
+          <ConfirmTxEnterSecretsFooter
+            address={account.id}
+            publicKey={account.publicKey}
+            secondPublicKey={passphrasePublicKey || account.secondPublicKey}
+            onConfirm={this.handleConfirmTransaction}
+          />
+        )}
       </ConfirmTransactionDialogContent>
     );
   }
@@ -550,7 +543,6 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       } else {
         // Make sure that the timeout clears the selected account
         this.lastLedgerSignId += 1;
-        this.goBack();
       }
     });
 

--- a/src/containers/wallet/ConfirmTransactionDialog.tsx
+++ b/src/containers/wallet/ConfirmTransactionDialog.tsx
@@ -203,8 +203,6 @@ class ConfirmTransactionDialog extends React.Component<Props, State>
       }
     }
 
-    // TODO this should switch the dialog to the SENT state when using ledger
-    //  works well for non-ledger signed txes
     if (success) {
       this.setState({
         step: 'sent',

--- a/src/containers/wallet/DrawerContent.tsx
+++ b/src/containers/wallet/DrawerContent.tsx
@@ -16,6 +16,7 @@ import AccountBalanceWalletIcon from '@material-ui/icons/AccountBalanceWallet';
 import AddIcon from '@material-ui/icons/Add';
 import AppsIcon from '@material-ui/icons/Apps';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import UsbIcon from '@material-ui/icons/Usb';
 import PeopleIcon from '@material-ui/icons/People';
 import * as classNames from 'classnames';
 import { orderBy } from 'lodash';
@@ -38,6 +39,7 @@ import {
   onboardingInstallToHomeScreenRoute
 } from '../../routes';
 import AccountStore from '../../stores/account';
+import LedgerStore from '../../stores/ledger';
 import { RouteLink } from '../../stores/root';
 import WalletStore from '../../stores/wallet';
 
@@ -88,6 +90,7 @@ type DecoratedProps = Props & InjectedIntlProps;
 interface PropsInjected extends DecoratedProps {
   routerStore: RouterStore;
   walletStore: WalletStore;
+  ledgerStore: LedgerStore;
 }
 
 const stylesDecorator = withStyles(styles, { name: 'DrawerContent' });
@@ -112,6 +115,7 @@ const messages = defineMessages({
 
 @inject('routerStore')
 @inject('walletStore')
+@inject('ledgerStore')
 @observer
 class DrawerContent extends React.Component<DecoratedProps> {
   get injected(): PropsInjected {
@@ -149,6 +153,12 @@ class DrawerContent extends React.Component<DecoratedProps> {
     return list;
   }
 
+  handleUnmountLedger = () => {
+    const { ledgerStore } = this.injected;
+    ledgerStore.close();
+    ledgerStore.forgetLastDevice();
+  }
+
   render() {
     const {
       intl,
@@ -156,7 +166,8 @@ class DrawerContent extends React.Component<DecoratedProps> {
       onAfterNavigate,
       onSignOutClick,
       routerStore,
-      walletStore
+      walletStore,
+      ledgerStore
     } = this.injected;
 
     const { selectedAccount } = walletStore;
@@ -345,6 +356,20 @@ class DrawerContent extends React.Component<DecoratedProps> {
                 </ListItem>
               </Link>
             )}
+          {ledgerStore.lastDevice && (
+            <ListItem button={true} onClick={this.handleUnmountLedger}>
+              <ListItemIcon className={classes.listIcon}>
+                <UsbIcon />
+              </ListItemIcon>
+              <ListItemText>
+                <FormattedMessage
+                  id="drawer-content.unmount-ledger"
+                  description="Unmount a ledger device drawer item"
+                  defaultMessage="Unmount Ledger"
+                />
+              </ListItemText>
+            </ListItem>
+          )}
           {!walletStore.isMobile &&
             walletStore.supportsA2HS &&
             !walletStore.isHomeScreen && (

--- a/src/containers/wallet/RegisterDelegateDialog.tsx
+++ b/src/containers/wallet/RegisterDelegateDialog.tsx
@@ -6,11 +6,12 @@ import {
   ICloseInterruptController,
   ICloseInterruptControllerState
 } from '../../components/Dialog';
+import LedgerStore from '../../stores/ledger';
 import ConfirmTransactionDialog from './ConfirmTransactionDialog';
 import RegisterDelegateDialogContent from '../../components/content/RegisterDelegateDialogContent';
 import { accountSettingsDelegateRoute } from '../../routes';
 import RootStore, { RouteLink } from '../../stores/root';
-import AccountStore, { LoadingState } from '../../stores/account';
+import AccountStore, { LoadingState, AccountType } from '../../stores/account';
 import WalletStore from '../../stores/wallet';
 
 interface Props {
@@ -23,6 +24,7 @@ interface PropsInjected extends Props {
   store: RootStore;
   routerStore: RouterStore;
   walletStore: WalletStore;
+  ledgerStore: LedgerStore;
 }
 
 interface State extends ICloseInterruptControllerState {
@@ -36,6 +38,7 @@ interface State extends ICloseInterruptControllerState {
 @inject('store')
 @inject('routerStore')
 @inject('walletStore')
+@inject('ledgerStore')
 @observer
 class RegisterDelegateDialog extends React.Component<Props, State>
   implements ICloseInterruptController {
@@ -48,6 +51,10 @@ class RegisterDelegateDialog extends React.Component<Props, State>
 
   get injected(): PropsInjected {
     return this.props as PropsInjected;
+  }
+
+  get account(): AccountStore {
+    return this.injected.account;
   }
 
   handleClose = (ev: React.SyntheticEvent<{}>) => {
@@ -84,6 +91,11 @@ class RegisterDelegateDialog extends React.Component<Props, State>
 
   handleUsernameCommit = () => {
     const { usernameInput } = this.state;
+
+    // ledger requires to be open in a click handler
+    if (this.account.type === AccountType.LEDGER) {
+      this.injected.ledgerStore.open();
+    }
 
     this.setState({
       step: 'transaction',

--- a/src/containers/wallet/SendCoinsDialog.tsx
+++ b/src/containers/wallet/SendCoinsDialog.tsx
@@ -57,7 +57,7 @@ class SendCoinsDialog extends React.Component<Props, State>
   };
 
   get account(): AccountStore {
-    return this.injected.account
+    return this.injected.account;
   }
 
   get injected(): PropsInjected {
@@ -102,10 +102,9 @@ class SendCoinsDialog extends React.Component<Props, State>
 
     // ledger requires to be open in a click handler
     if (this.account.type === AccountType.LEDGER) {
-      this.injected.ledgerStore.open()
+      this.injected.ledgerStore.open();
     }
 
-    debugger
     this.setState({
       recipientID,
       amount,
@@ -128,7 +127,6 @@ class SendCoinsDialog extends React.Component<Props, State>
         account.id
       );
     } else {
-      debugger
       throw new Error('Invalid internal state');
     }
   }
@@ -136,7 +134,6 @@ class SendCoinsDialog extends React.Component<Props, State>
   resetState() {
     const { recipientID, amount } = this.props;
 
-    console.log('reset state')
     this.setState({
       recipientID: recipientID || '',
       amount: amount || null,

--- a/src/containers/wallet/Settings.tsx
+++ b/src/containers/wallet/Settings.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../routes';
 import { accountStore } from '../../stores';
 import AccountStore, { AccountType, LoadingState } from '../../stores/account';
+import LedgerStore from '../../stores/ledger';
 import { RouteLink } from '../../stores/root';
 import WalletStore from '../../stores/wallet';
 import AccountNameDialog from './AccountNameDialog';
@@ -67,6 +68,7 @@ interface PropsInjected extends Props {
   accountStore: AccountStore;
   routerStore: RouterStore;
   walletStore: WalletStore;
+  ledgerStore: LedgerStore;
 }
 
 type DecoratedProps = Props & InjectedIntlProps;
@@ -170,6 +172,7 @@ const messages = defineMessages({
 @inject(accountStore)
 @inject('routerStore')
 @inject('walletStore')
+@inject('ledgerStore')
 @observer
 class AccountSettings extends React.Component<DecoratedProps, State> {
   state: State = {
@@ -187,6 +190,10 @@ class AccountSettings extends React.Component<DecoratedProps, State> {
   }
 
   // CLICK HANDLERS
+
+  handleVerifyLedgerClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    this.injected.ledgerStore.open();
+  }
 
   handlePinnedClicked = () => {
     runInAction(() => {
@@ -387,6 +394,7 @@ class AccountSettings extends React.Component<DecoratedProps, State> {
             {accountType === AccountType.LEDGER && (
               <Link
                 route={accountSettingsLedgerRoute}
+                onClick={this.handleVerifyLedgerClick}
                 params={{
                   id: this.account.id
                 }}

--- a/src/containers/wallet/VerifyLedgerDialog.tsx
+++ b/src/containers/wallet/VerifyLedgerDialog.tsx
@@ -73,11 +73,12 @@ const stylesDecorator = withStyles(styles, {
 });
 
 const messages = defineMessages({
-  connectInstructions: {
+  connectInstructionsV2: {
     id: 'verify-ledger-address.connect-instructions',
     description:
       'Text instructing the user to open the RISE app on their Ledger device',
-    defaultMessage: 'Connect your Ledger & open the RISE app on it.'
+    defaultMessage:
+      'Connect your Ledger, open the RISE app and click Discover Device below.'
   },
   unsupportedBrowser: {
     id: 'verify-ledger-address.unsupported-browser',
@@ -172,6 +173,10 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
       title: intl.formatMessage(messages.dialogTitle),
       contentId: this.dialogContentId
     });
+  }
+
+  onDiscoverLedger = () => {
+    this.injected.ledgerStore.open();
   }
 
   onClose = () => {
@@ -280,12 +285,12 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
           <Grid container={true} className={classes.content} spacing={16}>
             <Grid item={true} xs={12}>
               <Typography
-                children={intl.formatMessage(messages.connectInstructions)}
+                children={intl.formatMessage(messages.connectInstructionsV2)}
               />
             </Grid>
             <Grid item={true} xs={12}>
               <div className={classes.noPadding}>
-                <LedgerConnectIllustration />
+                <LedgerConnectIllustration onClick={this.onDiscoverLedger} />
               </div>
             </Grid>
             <Grid item={true} xs={12}>

--- a/src/containers/wallet/VerifyLedgerDialog.tsx
+++ b/src/containers/wallet/VerifyLedgerDialog.tsx
@@ -82,9 +82,9 @@ const messages = defineMessages({
   unsupportedBrowser: {
     id: 'verify-ledger-address.unsupported-browser',
     description:
-      'Message when trying to use a browser that doesn\'t support Ledger devices',
+      "Message when trying to use a browser that doesn't support Ledger devices",
     defaultMessage:
-      'Your browser doesn\'t support using a Ledger device. If you wish to access this feature, ' +
+      "Your browser doesn't support using a Ledger device. If you wish to access this feature, " +
       'you could try again with Google Chrome. It is a browser known to implement support for this.'
   },
   statusConnecting: {
@@ -177,7 +177,7 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
     });
 
     this.handleVerifyLedger();
-  }
+  };
 
   onClose = () => {
     if (!this.open) {
@@ -189,9 +189,9 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
       this.disposeLedgerChangeMonitor = null;
     }
 
-    this.injected.ledgerStore.open();
+    this.injected.ledgerStore.close();
     this.setState({ confirmed: false });
-  }
+  };
 
   @action
   updateSelectionCountdown = () => {
@@ -210,11 +210,11 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
       window.clearInterval(this.countdownId);
       this.countdownId = null;
     }
-  }
+  };
 
   handleVerifyLedger = async () => {
     const { ledgerStore } = this.injected;
-    if (!ledgerStore.deviceId || this.state.confirmed) {
+    if (!ledgerStore.device || this.state.confirmed) {
       return;
     }
 
@@ -229,12 +229,12 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
       console.log(e);
       // silent
     }
-  }
+  };
 
   handleCloseButton = () => {
     this.onClose();
     this.injected.store.navigateTo(this.injected.navigateBackLink);
-  }
+  };
 
   render() {
     const {
@@ -246,7 +246,7 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
       ledgerStore
     } = this.injected;
     const account = this.account;
-    let deviceId;
+    let device;
     let confirmed;
 
     const isOpen =
@@ -255,7 +255,7 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
     if (isOpen) {
       this.onOpen();
 
-      deviceId = ledgerStore.deviceId;
+      device = ledgerStore.device;
       confirmed = this.state.confirmed;
     } else if (this.open) {
       // TODO dialog doesnt call onClose if onCloseRoute is passed along
@@ -276,7 +276,7 @@ class VerifyLedgerDialog extends React.Component<DecoratedProps, State> {
               />
             </Grid>
           </Grid>
-        ) : !deviceId ? (
+        ) : !device ? (
           <Grid container={true} className={classes.content} spacing={16}>
             <Grid item={true} xs={12}>
               <Typography

--- a/src/containers/wallet/VoteDelegateDialog.tsx
+++ b/src/containers/wallet/VoteDelegateDialog.tsx
@@ -8,12 +8,13 @@ import {
   ICloseInterruptController,
   ICloseInterruptControllerState
 } from '../../components/Dialog';
+import LedgerStore from '../../stores/ledger';
 import { normalizeAddress } from '../../utils/utils';
 import ConfirmTransactionDialog from './ConfirmTransactionDialog';
 import VoteDelegateDialogContent from '../../components/content/VoteDelegateDialogContent';
 import { accountSettingsVoteRoute } from '../../routes';
 import RootStore, { RouteLink } from '../../stores/root';
-import AccountStore, { LoadingState } from '../../stores/account';
+import AccountStore, { LoadingState, AccountType } from '../../stores/account';
 import WalletStore from '../../stores/wallet';
 
 interface Props {
@@ -26,6 +27,7 @@ interface PropsInjected extends Props {
   store: RootStore;
   routerStore: RouterStore;
   walletStore: WalletStore;
+  ledgerStore: LedgerStore;
 }
 
 interface State extends ICloseInterruptControllerState {
@@ -46,11 +48,16 @@ interface State extends ICloseInterruptControllerState {
 @inject('store')
 @inject('routerStore')
 @inject('walletStore')
+@inject('ledgerStore')
 @observer
 class VoteDelegateDialog extends React.Component<Props, State>
   implements ICloseInterruptController {
   get injected(): PropsInjected {
     return this.props as PropsInjected;
+  }
+
+  get account(): AccountStore {
+    return this.injected.account;
   }
 
   get isOpen() {
@@ -178,6 +185,11 @@ class VoteDelegateDialog extends React.Component<Props, State>
   handleSelectDelegate = (delegate: Delegate) => {
     const { account } = this.injected;
     const { votedDelegate } = account;
+
+    // ledger requires to be open in a click handler
+    if (this.account.type === AccountType.LEDGER) {
+      this.injected.ledgerStore.open();
+    }
 
     let removeNames = [];
     let addNames = [];

--- a/src/stores/ledger.ts
+++ b/src/stores/ledger.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 /** Simple logging util (linter friendly) */
 // tslint:disable-next-line:no-unused-expression
 function log(...msg: string[]) {
-  // console.log(...msg);
+  console.log(...msg);
 }
 
 export interface LedgerAccount {
@@ -61,6 +61,7 @@ export default class LedgerStore {
   @observable isOpen: boolean = false;
   // @observable deviceId: null | string = null;
   @observable device: null | USBDevice = null;
+  @observable lastDevice: null | USBDevice = null;
   @observable transport: null | Transport = null;
   @observable eventContext: React.MouseEvent<HTMLAnchorElement>;
   confirmationTimeout = 30000;
@@ -94,16 +95,24 @@ export default class LedgerStore {
   }
 
   async open(): Promise<boolean> {
-    const transport = await TransportWebUSB.create();
+    const transport = this.lastDevice
+      ? await TransportWebUSB.open(this.lastDevice)
+      : await TransportWebUSB.create();
     if (!transport) {
       return false;
     }
     runInAction(() => {
       this.transport = transport;
       this.device = transport.device;
+      this.lastDevice = transport.device;
       this.isOpen = true;
     });
     return true;
+  }
+
+  @action
+  forgetLastDevice() {
+    this.lastDevice = null;
   }
 
   @action

--- a/src/stores/ledger.ts
+++ b/src/stores/ledger.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 /** Simple logging util (linter friendly) */
 // tslint:disable-next-line:no-unused-expression
 function log(...msg: string[]) {
-  console.log(...msg);
+  // console.log(...msg);
 }
 
 export interface LedgerAccount {

--- a/src/utils/typesGlobal.d.ts
+++ b/src/utils/typesGlobal.d.ts
@@ -1,4 +1,4 @@
-///<reference path="../../desktop/node_modules/electron/electron.d.ts"/>
+///<reference path="../../node_modules/@types/w3c-web-usb/index.d.ts"/>
 
 declare const ipcRenderer: Electron.IpcRenderer;
 // absolute modules path for electronRequire

--- a/src/utils/typesGlobal.d.ts
+++ b/src/utils/typesGlobal.d.ts
@@ -12,3 +12,8 @@ declare var carlo: any;
 interface Window {
   riseRelease: string | null;
 }
+
+declare module '@ledgerhq/hw-transport-webusb' {
+  const e: any;
+  export default e;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,6 +7,7 @@ import { RawAmount } from './amounts';
 
 // magic...
 const epoch = Date.UTC(2016, 4, 24, 17, 0, 0, 0) / 1000;
+BigNumber.config({ EXPONENTIAL_AT: 1e+9 });
 
 export function timestampToUnix(timestamp: number) {
   return new Date((timestamp + epoch) * 1000).getTime();
@@ -78,7 +79,8 @@ export function normalizeNumber(intl: InjectedIntl, value: string): string {
     if (isNaN(n.toNumber())) {
       return '';
     }
-    return n.toString();
+    const minSafe = BigNumber.max(n, new BigNumber(0.00000001));
+    return minSafe.toString();
   } catch (e) {
     return '';
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,34 +85,34 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@ledgerhq/devices@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.48.0.tgz#b62cce08dd49a8bd4cbf0eda0e09bf8610e42b56"
-  integrity sha512-Rs0zhkjzJTps1hoHlwGLhPM8Poo8EzE55QGLWk4Q6oXoO/Nk6MRUrFaz2UuCBVQU5RaI2JPhDbwO9bPd9cVH1Q==
+"@ledgerhq/devices@^4.54.0":
+  version "4.54.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.54.0.tgz#6345f6c0e6cf8fc16ac1a476df610e69d273cd76"
+  integrity sha512-v6E4PK6bej/CmMSMVasFWWy1iyh42XaHmUpp5i992/n+PiVQQL5qnQlgXpCq2ZoFinfpnFc7y2lv3qSxAqQimQ==
   dependencies:
-    "@ledgerhq/errors" "^4.48.0"
+    "@ledgerhq/errors" "^4.54.0"
 
-"@ledgerhq/errors@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.48.0.tgz#3a2a65862de72641095db8ef72739d105524a68f"
-  integrity sha512-MM5Tvo+KBr+dQyc6F2d93eyepZdHCmrR9KjwuB2W8pjPBG9jYmtPM/+I72k9o22YXQ9FIyd1WJJaARJoOzWXOA==
+"@ledgerhq/errors@^4.54.0":
+  version "4.54.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.54.0.tgz#e0655188714ca3750d3964faa0f01ebf76ecd455"
+  integrity sha512-BbAiJHzw/EtIp/HBhDUTbAGj+1cYGGmnrlXSccIxt/MFwcgrX2KgPFbTIAiJJYmPkUSdY4eucyrB9YohzfGCkw==
 
-"@ledgerhq/hw-transport-u2f@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.48.0.tgz#0419f7d54c989d6119450d9e505aa54a5d701c1f"
-  integrity sha512-qqKlLWDDibwKGWIcL3c9DLr9DdA+71AS5GwWGIJaKaOyGYeMK6uuJrqPphXO2xvHkPNG1B56vpAFy3ojp1mtMA==
+"@ledgerhq/hw-transport-webusb@^4.48.0":
+  version "4.54.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-4.54.0.tgz#1afc199b48e23df00029adc0af46af4172491b4a"
+  integrity sha512-PFWbOssqUznldPSjEGg/ans3gLwc0lwfLuTmX0untKz0axAR4C4E4Lq3Sjw/xAhKLePUQ3rCFDs8ZUxH/xDLXQ==
   dependencies:
-    "@ledgerhq/errors" "^4.48.0"
-    "@ledgerhq/hw-transport" "^4.48.0"
-    u2f-api "0.2.7"
+    "@ledgerhq/devices" "^4.54.0"
+    "@ledgerhq/errors" "^4.54.0"
+    "@ledgerhq/hw-transport" "^4.54.0"
 
-"@ledgerhq/hw-transport@^4.48.0":
-  version "4.48.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.48.0.tgz#8fa09e46d9d9aab35db5679e0970e7fed2ee73bf"
-  integrity sha512-dZH/3dTXlhe3IFl+MRFePcC0TnSeQcaBuiq5t3yDA68qw7WZCbON9GKSO5Rex4yNx5v6BCHyzz1myBFJ7895iw==
+"@ledgerhq/hw-transport@^4.54.0":
+  version "4.54.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.54.0.tgz#befa14a4a3ba5810ca6b7ffbd6b94bce861ddf88"
+  integrity sha512-9UCr35O0Fn7ib0R9BsgY9jXHL/bGCQF66GYOD2GCwLWDVnK5eVewS6J+ljxhWOIsV75OcqJtylRO0mAGOD6tWg==
   dependencies:
-    "@ledgerhq/devices" "^4.48.0"
-    "@ledgerhq/errors" "^4.48.0"
+    "@ledgerhq/devices" "^4.54.0"
+    "@ledgerhq/errors" "^4.54.0"
     events "^3.0.0"
 
 "@material-ui/core@^3.7.0":
@@ -277,6 +277,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ledgerhq__hw-transport@^4.21.1":
+  version "4.21.1"
+  resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport/-/ledgerhq__hw-transport-4.21.1.tgz#ceaaeb4fbd91d0244f2e2ef382e352879f4f8f3f"
+  integrity sha512-TPsB6seugMHuqGa3xPz4CgjSlmQdVf4VltxHGcdDSG3Fu7nKqD1zZVE+AnULq4oIgs2lIRcGHiDCgN7kZFDeUw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/lodash@4.14.87":
   version "4.14.87"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.87.tgz#55f92183b048c2c64402afe472f8333f4e319a6b"
@@ -385,6 +392,11 @@
   version "1.4.32"
   resolved "https://registry.yarnpkg.com/@types/socket.io-client/-/socket.io-client-1.4.32.tgz#988a65a0386c274b1c22a55377fab6a30789ac14"
   integrity sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==
+
+"@types/w3c-web-usb@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.3.tgz#723a5b37865b64e891d8fffa2703a2e4d0250170"
+  integrity sha512-XilIvno46lLRyOj/1G5z88M6iimYs3dr3LNdSN9UxSWifytKsBMmRtAi53X3j0ThrrqyVotqrSeaYv9a0I131w==
 
 abab@^1.0.3:
   version "1.0.4"
@@ -10082,11 +10094,6 @@ typescript@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
   integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
-
-u2f-api@0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/u2f-api/-/u2f-api-0.2.7.tgz#17bf196b242f6bf72353d9858e6a7566cc192720"
-  integrity sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
This PR switches the Ledger support to webusb (fixes #224).

Included:
- ledger signing supports every type of transaction
- deep linking has UI element to activate webusb
- last used device is remembered
- user can unmount the device from the left menu

To test one has to have the newest (not yet released as of now) rise ledger-app.

Beta release:
https://github.com/RiseVision/rise-react-wallet/releases/tag/v1.2.0-beta2

Screenshots:
<img width="273" alt="Screen Shot 2019-04-30 at 2 05 08 PM" src="https://user-images.githubusercontent.com/93027/57012062-e76f2280-6c04-11e9-85fd-886bdc7389b5.png">
<img width="951" alt="Screen Shot 2019-04-30 at 2 05 53 PM" src="https://user-images.githubusercontent.com/93027/57012064-e807b900-6c04-11e9-8923-1694a94627be.png">
